### PR TITLE
fix(mssql): set correct scale for float

### DIFF
--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -9,6 +9,13 @@ const { logger } = require('../../utils/logger');
 
 const debug = logger.debugContext('sql:mssql');
 
+function getScale(aNum) {
+  if (!Number.isFinite(aNum)) return 0;
+  let e = 1;
+  while (Math.round(aNum * e) / e !== aNum) e *= 10;
+  return Math.log10(e);
+}
+
 class Query extends AbstractQuery {
   getInsertIdField() {
     return 'id';
@@ -27,7 +34,7 @@ class Query extends AbstractQuery {
       } else {
         paramType.type = TYPES.Numeric;
         //Default to a reasonable numeric precision/scale pending more sophisticated logic
-        paramType.typeOptions = { precision: 30, scale: 15 };
+        paramType.typeOptions = { precision: 30, scale: getScale(value) };
       }
     }
     if (Buffer.isBuffer(value)) {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

When we set type options of float for mssql, existing code blindly set it to precision 30, scale 15.
This could cause an issue with a large float value e.g. 43069.0122916667.
see issue https://github.com/tediousjs/tedious/issues/1058
and https://github.com/sequelize/sequelize/issues/11959
to minimize the impact of the issue, we should at least set the scale correctly.

